### PR TITLE
3주차(필수,선택) : user엔티티 추가, 공개여부 기능 추가, 페이징 처리 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,17 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="50e00b5c-0bcc-4c5e-839d-eabf1186306b" name="변경" comment="">
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/SignUpRequest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/api/DiaryController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/api/DiaryController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryUpdateRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryUpdateRequest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/model/Category.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/model/Category.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/repository/DiaryEntity.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/repository/DiaryEntity.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/repository/DiaryRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/repository/DiaryRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/Diary.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/model/Diary.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/DiaryService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/DiaryService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/DiaryTimeService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/DiaryTimeService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -64,11 +74,11 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "last_opened_file_path": "C:/Sopt_WangChobo"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;last_opened_file_path&quot;: &quot;C:/Sopt_WangChobo&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration name="DiaryApplication" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="org.sopt.diary.DiaryApplication" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,26 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="50e00b5c-0bcc-4c5e-839d-eabf1186306b" name="변경" comment="">
-      <change afterPath="$PROJECT_DIR$/.idea/.name" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/DiaryApplication.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/api/DiaryController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryCreateRequest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryDetailResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryDirectoryResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryListResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/dto/DiaryUpdateRequest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/handler/GlobalExceptionHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/model/Category.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/repository/DiaryEntity.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/repository/DiaryRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/Diary.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/DiaryService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/service/DiaryTimeService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/diary/validator/DiaryValidator.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -83,16 +64,11 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">
-    <option name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
-    <option name="RunOnceActivity.ShowReadmeOnStart" value="true" />
-    <option name="SHARE_PROJECT_CONFIGURATION_FILES" value="true" />
-    <option name="onboarding.tips.debug.path" value="$PROJECT_DIR$/../SOPT/homework/src/main/java/org/sopt/Main.java" />
-    <option name="project.structure.last.edited" value="프로젝트" />
-    <option name="project.structure.proportion" value="0.15" />
-    <option name="project.structure.side.proportion" value="0.2" />
-    <option name="settings.editor.selected.configurable" value="org.jetbrains.plugins.github.ui.GithubSettingsConfigurable" />
-  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "last_opened_file_path": "C:/Sopt_WangChobo"
+  }
+}]]></component>
   <component name="RunManager">
     <configuration name="DiaryApplication" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="org.sopt.diary.DiaryApplication" />

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -1,71 +1,105 @@
 package org.sopt.diary.api;
 
 import org.sopt.diary.model.Category;
-
 import org.sopt.diary.dto.*;
-import org.sopt.diary.service.Diary;
 import org.sopt.diary.service.DiaryService;
+import org.sopt.diary.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
 public class DiaryController {
     private final DiaryService diaryService;
+    private final UserService userService;
 
-    public DiaryController(DiaryService diaryService) {
+    public DiaryController(DiaryService diaryService, UserService userService) {
         this.diaryService = diaryService;
+        this.userService = userService;
     }
 
     @PostMapping("/diaries")
-    ResponseEntity<DiaryResponse> createDiary(@RequestBody DiaryCreateRequest diaryCreateRequest) {
-        DiaryResponse diaryResponse = diaryService.createDiary(diaryCreateRequest);
+    ResponseEntity<DiaryResponse> createDiary(
+            @RequestHeader("userId") Long userId,
+            @RequestBody DiaryCreateRequest diaryCreateRequest) {
+        DiaryResponse diaryResponse = diaryService.createDiary(userId, diaryCreateRequest);
         return ResponseEntity.ok(diaryResponse);
     }
 
     @GetMapping("/diaries/list")
-    public ResponseEntity<List<DiaryDirectoryResponse>> getDiaryList(
+    public ResponseEntity<Page<DiaryDirectoryResponse>> getDiaryList(
+            @RequestHeader("userId") Long userId,
             @RequestParam(value = "category", required = false) Category category,
-            @RequestParam(value = "orderBy", required = false) String orderBy) {
+            @RequestParam(value = "orderBy", required = false) String orderBy,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
 
-        List<DiaryDirectoryResponse> diaryDirectoryResponses;
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<DiaryDirectoryResponse> diaryDirectoryResponses;
 
         if (category != null) {
             if ("bodyLength".equals(orderBy)) {
-                diaryDirectoryResponses = diaryService.getDiaryByCategoryLength(category);
+                diaryDirectoryResponses = diaryService.getDiaryByCategoryLength(userId, category, pageRequest);
             } else {
-                diaryDirectoryResponses = diaryService.getDiaryByCategory(category);
+                diaryDirectoryResponses = diaryService.getDiaryByCategory(userId, category, pageRequest);
             }
         } else {
             if ("bodyLength".equals(orderBy)) {
-                diaryDirectoryResponses = diaryService.getSortDiary();
+                diaryDirectoryResponses = diaryService.getSortDiary(userId, pageRequest);
             } else {
-                diaryDirectoryResponses = diaryService.getDiaryList();
+                diaryDirectoryResponses = diaryService.getDiaryList(userId, pageRequest);
             }
         }
         return ResponseEntity.ok(diaryDirectoryResponses);
     }
 
     @GetMapping("/diaries/{id}")
-    public ResponseEntity<DiaryDetailResponse> getDiaryDetail(@PathVariable long id) {
-        DiaryDetailResponse diaryDetailResponse = diaryService.getDiaryDetail(id);
+    public ResponseEntity<DiaryDetailResponse> getDiaryDetail(
+            @RequestHeader("userId") Long userId,
+            @PathVariable long id) {
+        DiaryDetailResponse diaryDetailResponse = diaryService.getDiaryDetail(userId, id);
         return ResponseEntity.ok(diaryDetailResponse);
     }
 
     @PatchMapping("/diaries/{id}")
     public ResponseEntity<DiaryResponse> updateDiaryBody(
+            @RequestHeader("userId") Long userId,
             @PathVariable Long id,
             @RequestBody DiaryUpdateRequest diaryUpdateRequest) {
-
-        DiaryResponse diaryResponse = diaryService.updateDiary(id, diaryUpdateRequest);
+        DiaryResponse diaryResponse = diaryService.updateDiary(userId, id, diaryUpdateRequest);
         return ResponseEntity.ok(diaryResponse);
     }
 
     @DeleteMapping("/diaries/{id}")
-    public ResponseEntity<DiaryResponse> deleteDiary(@PathVariable Long id) {
-        DiaryResponse diaryResponse = diaryService.deleteDiary(id);
+    public ResponseEntity<DiaryResponse> deleteDiary(
+            @RequestHeader("userId") Long userId,
+            @PathVariable Long id) {
+        DiaryResponse diaryResponse = diaryService.deleteDiary(userId, id);
+        return ResponseEntity.ok(diaryResponse);
+    }
+
+    @GetMapping("/diaries/home")
+    public ResponseEntity<List<DiaryDirectoryResponse>> getMainHome(
+            @RequestHeader("userId") Long userId) {
+        List<DiaryDirectoryResponse> diaryDirectoryResponses = diaryService.getMainHome(userId);
+        return ResponseEntity.ok(diaryDirectoryResponses);
+    }
+
+    @GetMapping("/diaries/my")
+    public ResponseEntity<List<DiaryDirectoryResponse>> getMyDiaries(
+            @RequestHeader("userId") Long userId) {
+        List<DiaryDirectoryResponse> diaryDirectoryResponses = diaryService.getMyDiaries(userId);
+        return ResponseEntity.ok(diaryDirectoryResponses);
+    }
+
+    @PatchMapping("/diaries/{id}/publish")
+    public ResponseEntity<DiaryResponse> publishDiary(
+            @PathVariable Long id,
+            @RequestParam Boolean isPublished) {
+        DiaryResponse diaryResponse = diaryService.publishDiary(id, isPublished);
         return ResponseEntity.ok(diaryResponse);
     }
 }

--- a/src/main/java/org/sopt/diary/api/UserController.java
+++ b/src/main/java/org/sopt/diary/api/UserController.java
@@ -1,0 +1,34 @@
+package org.sopt.diary.api;
+
+import org.sopt.diary.dto.SignUpRequest;
+import org.sopt.diary.dto.SignInRequest;
+import org.sopt.diary.dto.UserResponse;
+import org.sopt.diary.repository.UserEntity;
+import org.sopt.diary.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/user/signup")
+    public ResponseEntity<UserResponse> signUp(@RequestBody SignUpRequest signUpRequest) {
+        UserEntity userEntity = userService.signUp(signUpRequest);
+        UserResponse userResponse = new UserResponse(userEntity.getId(), userEntity.getUsername(), userEntity.getNickname());
+        return ResponseEntity.ok(userResponse);
+    }
+
+    @PostMapping("/user/signin")
+    public ResponseEntity<UserResponse> signIn(@RequestBody SignInRequest signInRequest) {
+        UserEntity userEntity = userService.signIn(signInRequest);
+        UserResponse userResponse = new UserResponse(userEntity.getId(), userEntity.getUsername(), userEntity.getNickname());
+        return ResponseEntity.ok(userResponse);
+    }
+}

--- a/src/main/java/org/sopt/diary/dto/DiaryResponse.java
+++ b/src/main/java/org/sopt/diary/dto/DiaryResponse.java
@@ -7,8 +7,10 @@ public class DiaryResponse {
     private String title;
 
     private String body;
+    private boolean isPublished;
 
-    public DiaryResponse(long id, String title, String body) {
+    public DiaryResponse(long id, String title, String body, boolean isPublished) {
+        this.isPublished = isPublished;
         this.id = id;
         this.title = title;
         this.body = body;
@@ -24,5 +26,9 @@ public class DiaryResponse {
 
     public String getBody() {
         return body;
+    }
+
+    public boolean isPublished() {
+        return isPublished;
     }
 }

--- a/src/main/java/org/sopt/diary/dto/DiaryUpdateRequest.java
+++ b/src/main/java/org/sopt/diary/dto/DiaryUpdateRequest.java
@@ -2,11 +2,13 @@ package org.sopt.diary.dto;
 
 public class DiaryUpdateRequest {
     private String body;
+    private boolean isPublished;
 
     public DiaryUpdateRequest() {
     }
 
-    public DiaryUpdateRequest(String body) {
+    public DiaryUpdateRequest(String body, boolean isPublished) {
+        this.isPublished = isPublished;
         this.body = body;
     }
 
@@ -16,5 +18,9 @@ public class DiaryUpdateRequest {
 
     public void setBody(String body) {
         this.body = body;
+    }
+
+    public boolean isPublished() {
+        return isPublished;
     }
 }

--- a/src/main/java/org/sopt/diary/dto/SignInRequest.java
+++ b/src/main/java/org/sopt/diary/dto/SignInRequest.java
@@ -1,0 +1,19 @@
+package org.sopt.diary.dto;
+
+public class SignInRequest {
+    private String username;
+    private String password;
+
+    public SignInRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/org/sopt/diary/dto/SignUpRequest.java
+++ b/src/main/java/org/sopt/diary/dto/SignUpRequest.java
@@ -1,0 +1,25 @@
+package org.sopt.diary.dto;
+
+public class SignUpRequest {
+    private String username;
+    private String password;
+    private String nickname;
+
+    public SignUpRequest(String username, String password, String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/src/main/java/org/sopt/diary/dto/UserResponse.java
+++ b/src/main/java/org/sopt/diary/dto/UserResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.diary.dto;
+
+public class UserResponse {
+    private Long userId;
+    private String username;
+    private String nickname;
+
+    public UserResponse(Long userId, String username, String nickname) {
+        this.userId = userId;
+        this.username = username;
+        this.nickname = nickname;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/org/sopt/diary/model/Category.java
+++ b/src/main/java/org/sopt/diary/model/Category.java
@@ -2,7 +2,7 @@ package org.sopt.diary.model;
 
 public enum Category {
     FOOD,
-    WORKOUT,
-    STUDY,
-    HOBBY
+    SCHOOL,
+    MOVIE,
+    EXERCISE
 }

--- a/src/main/java/org/sopt/diary/model/Diary.java
+++ b/src/main/java/org/sopt/diary/model/Diary.java
@@ -1,4 +1,4 @@
-package org.sopt.diary.service;
+package org.sopt.diary.model;
 
 public class Diary {
     private final long id;

--- a/src/main/java/org/sopt/diary/repository/DiaryEntity.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryEntity.java
@@ -8,41 +8,67 @@ import java.time.LocalDateTime;
 public class DiaryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    private Long id;
 
     @Column(unique = true)
-    public String title;
+    private String title;
 
     @Column
-    public String body;
+    private String body;
 
     @Column
-    public LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
-    public Category category;
+    private Category category;
+
+    @Column
+    private boolean isPublished = false;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;  // UserEntity로 변경하여 타입 일치
 
     public DiaryEntity() {
-
     }
 
-    public DiaryEntity(final String title, final String body, final Category category) {
+    public DiaryEntity(final String title, final String body, final Category category, final UserEntity user) {
         this.title = title;
         this.body = body;
         this.category = category;
+        this.user = user;
         this.createdAt = LocalDateTime.now();
     }
 
     public Long getId() {
         return id;
     }
+
     public String getTitle() {
         return title;
     }
+
     public String getBody() {
         return body;
     }
+
     public LocalDateTime getCreateAt() {
         return createdAt;
+    }
+
+    public UserEntity getUser() {
+        return user;
+    }
+
+    public void updateBody(String body) {
+        this.body = body;
+    }
+
+    public boolean isPublished() {
+        return isPublished;
+    }
+
+    public void setPublished(boolean published) {
+        isPublished = published;
     }
 }

--- a/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -1,10 +1,10 @@
 package org.sopt.diary.repository;
 
 import org.sopt.diary.model.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -13,7 +13,10 @@ import java.util.Optional;
 
 @Component
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
+
     List<DiaryEntity> findTop10ByOrderByCreatedAtDesc();
+
+    Page<DiaryEntity> findTop10ByOrderByCreatedAtDesc(Pageable pageable);
 
     @Query("SELECT d.createdAt FROM DiaryEntity d ORDER BY d.createdAt DESC")
     Optional<LocalDateTime> findTopByOrderByCreatedAtDesc();
@@ -21,10 +24,27 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
     @Query("SELECT d FROM DiaryEntity d ORDER BY LENGTH(d.body) DESC")
     List<DiaryEntity> findTop10ByOrderByBodyLengthDesc();
 
+    @Query("SELECT d FROM DiaryEntity d ORDER BY LENGTH(d.body) DESC")
+    Page<DiaryEntity> findTop10ByOrderByBodyLengthDesc(Pageable pageable);
+
     boolean existsByTitle(String title);
 
     List<DiaryEntity> findByCategory(Category category);
 
+    Page<DiaryEntity> findByCategory(Category category, Pageable pageable);
+
     @Query("SELECT d FROM DiaryEntity d WHERE d.category = :category ORDER BY LENGTH(d.body) DESC")
     List<DiaryEntity> findByCategoryOrderByBodyLengthDesc(Category category);
+
+    @Query("SELECT d FROM DiaryEntity d WHERE d.category = :category ORDER BY LENGTH(d.body) DESC")
+    Page<DiaryEntity> findByCategoryOrderByBodyLengthDesc(Category category, Pageable pageable);
+
+    @Query("SELECT d FROM DiaryEntity d WHERE d.user.id = :userId ORDER BY d.createdAt DESC")
+    List<DiaryEntity> findMainHomeByUserId(Long userId);
+
+    @Query("SELECT d FROM DiaryEntity d WHERE d.user.id = :userId ORDER BY d.createdAt DESC")
+    Page<DiaryEntity> findMainHomeByUserId(Long userId, Pageable pageable);
+
+    List<DiaryEntity> findByUserId(Long userId);
+
 }

--- a/src/main/java/org/sopt/diary/repository/UserEntity.java
+++ b/src/main/java/org/sopt/diary/repository/UserEntity.java
@@ -1,0 +1,41 @@
+package org.sopt.diary.repository;
+
+import jakarta.persistence.*;
+
+@Entity
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String username;
+
+    @Column
+    private String password;
+
+    @Column
+    private String nickname;
+
+    public UserEntity() {
+
+    }
+
+    public UserEntity(final String username, final String password, final String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/src/main/java/org/sopt/diary/repository/UserRepository.java
+++ b/src/main/java/org/sopt/diary/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.diary.repository;
+
+import org.sopt.diary.repository.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUsernameAndPassword(String username, String password);
+}

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -4,12 +4,14 @@ import org.sopt.diary.model.Category;
 import org.sopt.diary.dto.*;
 import org.sopt.diary.repository.DiaryEntity;
 import org.sopt.diary.repository.DiaryRepository;
+import org.sopt.diary.repository.UserEntity;
+import org.sopt.diary.repository.UserRepository;
 import org.sopt.diary.validator.DiaryValidator;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -18,71 +20,93 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final DiaryTimeService diaryTimeService;
     private final DiaryValidator diaryValidator;
+    private final UserRepository userRepository;
 
-    public DiaryService(DiaryRepository diaryRepository, DiaryTimeService diaryTimeService, DiaryValidator diaryValidator) {
+    public DiaryService(DiaryRepository diaryRepository, DiaryTimeService diaryTimeService, DiaryValidator diaryValidator, UserRepository userRepository) {
         this.diaryRepository = diaryRepository;
         this.diaryTimeService = diaryTimeService;
         this.diaryValidator = diaryValidator;
+        this.userRepository = userRepository;
     }
 
-    public DiaryResponse createDiary(DiaryCreateRequest diaryCreateRequest) {
+    public DiaryResponse createDiary(Long userId, DiaryCreateRequest diaryCreateRequest) {
         if (!diaryTimeService.fiveTimeCheck()) {
             throw new IllegalArgumentException("아직 5분 안됐어요");
         }
 
         diaryValidator.validate(diaryCreateRequest);
 
-        DiaryEntity diaryEntity = new DiaryEntity(diaryCreateRequest.getTitle(), diaryCreateRequest.getBody(), diaryCreateRequest.getCategory());
-        DiaryEntity saveDiary = diaryRepository.save(diaryEntity);
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
 
-        return new DiaryResponse(saveDiary.getId(), saveDiary.getTitle(), saveDiary.getBody());
+        DiaryEntity diaryEntity = new DiaryEntity(diaryCreateRequest.getTitle(), diaryCreateRequest.getBody(), diaryCreateRequest.getCategory(), user);
+        DiaryEntity savedDiary = diaryRepository.save(diaryEntity);
+
+        return new DiaryResponse(savedDiary.getId(), savedDiary.getTitle(), savedDiary.getBody(), savedDiary.isPublished());
     }
 
-    public List<DiaryDirectoryResponse> getDiaryList() {
-        List<DiaryEntity> diaryEntities = diaryRepository.findTop10ByOrderByCreatedAtDesc();
-
-        return mapToDiaryResponse(diaryEntities);
+    public Page<DiaryDirectoryResponse> getDiaryList(Long userId, Pageable pageable) {
+        return diaryRepository.findTop10ByOrderByCreatedAtDesc(pageable)
+                .map(diaryEntity -> new DiaryDirectoryResponse(diaryEntity.getId(), diaryEntity.getTitle()));
     }
 
-    public List<DiaryDirectoryResponse> getDiaryByCategoryLength(Category category) {
-        List<DiaryEntity> diaryEntities = diaryRepository.findByCategoryOrderByBodyLengthDesc(category);
-        return mapToDiaryResponse(diaryEntities);
+    public Page<DiaryDirectoryResponse> getDiaryByCategoryLength(Long userId, Category category, Pageable pageable) {
+        return diaryRepository.findByCategoryOrderByBodyLengthDesc(category, pageable)
+                .map(diaryEntity -> new DiaryDirectoryResponse(diaryEntity.getId(), diaryEntity.getTitle()));
     }
 
-    public DiaryDetailResponse getDiaryDetail(long id) {
+    public DiaryDetailResponse getDiaryDetail(Long userId, long id) {
         DiaryEntity diaryEntity = findDiaryByIdOrThrow(id);
-
         return new DiaryDetailResponse(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getBody(), diaryEntity.getCreateAt());
     }
 
-    public DiaryResponse updateDiary(long id, DiaryUpdateRequest diaryUpdateRequest) {
+    public DiaryResponse updateDiary(Long userId, Long id, DiaryUpdateRequest diaryUpdateRequest) {
         DiaryEntity existingDiary = findDiaryByIdOrThrow(id);
-
-        // 본문만 업데이트
-        existingDiary.body = diaryUpdateRequest.getBody();
+        if (!existingDiary.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("수정 권한이 없습니다");
+        }
+        existingDiary.updateBody(diaryUpdateRequest.getBody());
 
         diaryRepository.save(existingDiary);
-
-        return new DiaryResponse(existingDiary.getId(), existingDiary.getTitle(), existingDiary.getBody());
+        return new DiaryResponse(existingDiary.getId(), existingDiary.getTitle(), existingDiary.getBody(), existingDiary.isPublished());
     }
 
-    public DiaryResponse deleteDiary(Long id) {
+    public DiaryResponse deleteDiary(Long userId, Long id) {
         DiaryEntity diaryEntity = findDiaryByIdOrThrow(id);
-
+        if (!diaryEntity.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("삭제 권한이 없습니다");
+        }
         diaryRepository.deleteById(id);
-
-        return new DiaryResponse(id, diaryEntity.getTitle(), diaryEntity.getBody());
+        return new DiaryResponse(id, diaryEntity.getTitle(), diaryEntity.getBody(), diaryEntity.isPublished());
     }
 
-    public List<DiaryDirectoryResponse> getSortDiary() {
-        List<DiaryEntity> diaryEntities = diaryRepository.findTop10ByOrderByBodyLengthDesc();
-
-        return mapToDiaryResponse(diaryEntities);
+    public Page<DiaryDirectoryResponse> getSortDiary(Long userId, Pageable pageable) {
+        return diaryRepository.findTop10ByOrderByBodyLengthDesc(pageable)
+                .map(diaryEntity -> new DiaryDirectoryResponse(diaryEntity.getId(), diaryEntity.getTitle()));
     }
 
-    public List<DiaryDirectoryResponse> getDiaryByCategory(Category category) {
-        List<DiaryEntity> diaryEntities = diaryRepository.findByCategory(category);
-        return mapToDiaryResponse(diaryEntities);
+    public Page<DiaryDirectoryResponse> getDiaryByCategory(Long userId, Category category, Pageable pageable) {
+        return diaryRepository.findByCategory(category, pageable)
+                .map(diaryEntity -> new DiaryDirectoryResponse(diaryEntity.getId(), diaryEntity.getTitle()));
+    }
+
+    public List<DiaryDirectoryResponse> getMainHome(Long userId) {
+        List<DiaryEntity> diaries = diaryRepository.findMainHomeByUserId(userId);
+        return mapToDiaryResponse(diaries);
+    }
+
+    public List<DiaryDirectoryResponse> getMyDiaries(Long userId) {
+        List<DiaryEntity> diaries = diaryRepository.findByUserId(userId);
+        return mapToDiaryResponse(diaries);
+    }
+
+    public DiaryResponse publishDiary(Long id, boolean isPublished) {
+        DiaryEntity diaryEntity = diaryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 다이어리 ID"));
+        diaryEntity.setPublished(isPublished);
+        DiaryEntity saveDiary = diaryRepository.save(diaryEntity);
+
+        return new DiaryResponse(saveDiary.getId(), saveDiary.getTitle(), saveDiary.getBody(), saveDiary.isPublished());
     }
 
     private DiaryEntity findDiaryByIdOrThrow(Long id) {

--- a/src/main/java/org/sopt/diary/service/DiaryTimeService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryTimeService.java
@@ -1,6 +1,5 @@
 package org.sopt.diary.service;
 
-import org.sopt.diary.repository.DiaryEntity;
 import org.sopt.diary.repository.DiaryRepository;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/org/sopt/diary/service/UserService.java
+++ b/src/main/java/org/sopt/diary/service/UserService.java
@@ -1,0 +1,32 @@
+package org.sopt.diary.service;
+
+import org.sopt.diary.dto.SignInRequest;
+import org.sopt.diary.dto.SignUpRequest;
+import org.sopt.diary.repository.UserEntity;
+import org.sopt.diary.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserEntity signUp(SignUpRequest signUpRequest) {
+        UserEntity userEntity = new UserEntity(
+                signUpRequest.getUsername(),
+                signUpRequest.getPassword(),
+                signUpRequest.getNickname()
+        );
+        return userRepository.save(userEntity); // UserEntity 반환
+    }
+
+    public UserEntity signIn(SignInRequest signInRequest) {
+        return userRepository.findByUsernameAndPassword(
+                signInRequest.getUsername(),
+                signInRequest.getPassword()
+        ).orElseThrow(() -> new IllegalArgumentException("Invalid username or password"));
+    }
+}


### PR DESCRIPTION
## 🔍️ User 정보 추가

* DiaryEntity에 작성자 정보를 참조할 수 있는 UserEntity 필드를 추가했습니다. 이를 위해 다이어리 생성 시 UserEntity 객체가 필요하며, UserRepository에서 userId로 UserEntity를 조회하여 다이어리에 작성자 정보가 포함되도록 구현했습니다.
* 컨트롤러 레벨에서 HTTP 요청의 헤더에 userId를 포함해 전달하면, 이를 서비스 계층에서 받아서 다이어리를 저장할 때 작성자 정보가 포함되도록 했습니다.
* 관련 메서드 (createDiary, getMyDiaries 등)에서 userId에 따른 다이어리 조회, 작성 및 수정 권한 확인을 추가하여 안전한 다이어리 접근을 보장했습니다.

## 🔍️ 공개 여부 (Publish Status) 추가
> DiaryEntity에 isPublished 추가

* DiaryEntity에 isPublished라는 Boolean 필드를 추가했습니다. 이 필드는 다이어리의 공개 여부를 나타내며, 기본값은 false로 설정되어 비공개 상태입니다.
* 다이어리 작성 후에는 기본적으로 비공개이며, 사용자가 publishDiary 메서드를 호출하여 공개 상태를 설정할 수 있습니다.
* publishDiary 메서드는 다이어리의 ID를 받아 해당 다이어리를 공개 또는 비공개로 전환합니다.
* 공개 여부는 DiaryResponse에 포함되어 응답으로 반환됩니다.

## 🔍️ 페이징 처리
> DiaryRepository에 페이징 메서드를 정의하여, Spring Data JPA의 페이징 기능을 통해 Page<DiaryEntity>를 반환하도록 설정

* 다이어리 목록을 반환하는 주요 메서드 (getDiaryList, getDiaryByCategory, getSortDiary)에 Pageable 파라미터를 추가하여, 요청에 따라 데이터를 페이지 단위로 불러올 수 있도록 수정했습니다.
* 서비스 계층에서 Page<DiaryEntity> 객체를 받아 Page<DiaryDirectoryResponse>로 변환한 후 컨트롤러에서 반환합니다.
* 다이어리 목록 조회 시 요청 URL에 page, size, orderBy 등 파라미터를 통해 페이징 및 정렬 조건을 전달할 수 있으며, 응답에서 페이지 정보와 함께 다이어리 데이터가 포함됩니다.